### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "pygame"
+run = ""

--- a/README.md
+++ b/README.md
@@ -9,3 +9,5 @@ This is the version which is intended for use
 
 savedData.txt:
 Contains a list of saved hydrocarbons
+
+[![Run on Repl.it](https://repl.it/badge/github/Joe9238/Hydrocarbon-Simultor)](https://repl.it/github/Joe9238/Hydrocarbon-Simultor)


### PR DESCRIPTION
This pull request configures this repository to be run on Repl.it.      It adds a `.replit` configuration file and a Repl.it badge to the `README`.
     You can read more about running repos on Repl.it [here](https://docs.repl.it/repls/dot-replit), or view the Repl [here](https://repl.it/@JoeMaskell/Hydrocarbon-Simultor).